### PR TITLE
Documentation fix: 'yarn serve' should run in the correct folder.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Here is a sample:
 ```
 
 ## Running & Developing
-
+Navigate to the sub-folder `lsp-inspector`, and:
 - `yarn`
 - `yarn serve`
 


### PR DESCRIPTION
Under the "Running & Developing" section in the README.md page, the documentation does not specify which folder the yarn command should run, running it in the root folder does not provide the desired result. 

So I mention that you need to run it in 'lsp-inspector' folder.