### PR TITLE
added dialog to paste log from clipboard

### DIFF
--- a/lsp-inspector/src/components/sidebar/LogPastePopup.vue
+++ b/lsp-inspector/src/components/sidebar/LogPastePopup.vue
@@ -1,0 +1,194 @@
+<template>
+  <transition name="log-paste-popup">
+    <div class="lgp-mask" @click="close()">
+      <div class="lgp-wrapper">
+        <div class="lgp-container" @click.stop>
+          <div class="lgp-header">
+            <h1>Paste your log</h1>
+          </div>
+          <div class="lgp-content">
+            <div>
+              <input v-model="name" placeholder="Custom name"/>
+              <span class="lgp-error-text" v-show="isError">Could not parse log</span>
+            </div>
+            <div>
+              <textarea v-model="pasteText" @input="pasteTextChanged" placeholder="Your log"></textarea>
+            </div>
+            <div style="text-align: center">
+              <input type="button" value="Paste" @click="pasteText = handlePaste()"/>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </transition>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+export default Vue.extend({
+  mounted() {
+    document.addEventListener('keydown', (e) => {
+      if (e.keyCode === 27) {
+        this.close();
+      }
+    });
+  },
+  data() {
+    return {
+      name: '',
+      pasteText: '',
+      isError: false
+    }
+  },
+  methods: {
+    close() {
+      this.$emit('close');
+    },
+    handlePaste(e) {
+      const store = this.$store
+
+      this.isError = false
+      try {
+        store.commit('addLog', {
+          name: this.name || 'paste',
+          rawLog: this.pasteText
+        })
+      } catch (e) {
+        this.isError = true
+        return;
+      }
+
+      this.name = ''
+      this.pasteText = ''
+
+      this.close()
+    },
+    pasteTextChanged() {
+      const store = this.$store
+
+      function toUnusedName(basename: string): string {
+          const logNames = store.state.logs.map(log => log.name)
+          let name = basename
+          let i = 1
+          // generate names until we find one that is not in the store
+          while (logNames.includes(name)) {
+            name = `${basename} (${i})`
+            i++
+          }
+          return name
+      }
+
+      // if the user pastes his log file we try to extract the name which is the last part of the path in rootPath
+      // in the following log, for example, the name would be 'language-server-test'
+      /*
+        [Trace - 3:55:28 PM] Sending request 'initialize - (0)'.
+        Params: {
+            "processId": 28444,
+            "rootPath": "/home/user/workspace/language-server-test",
+            "rootUri": "file:///home/user/workspace/language-server-test",
+
+            ...
+      */
+      const NameSearchRegex = /"rootPath":\s*".*\/([^\"\/]+)\/?"/
+
+      if (!this.name) {
+        const match = NameSearchRegex.exec(this.pasteText)
+        if (match && match[1]) {
+          this.name = toUnusedName(match[1])
+        }
+      }
+    }
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+@import '@/scss/global.scss';
+
+.lgp-mask {
+  position: fixed;
+  z-index: 9998;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, .5);
+  display: table;
+  transition: opacity .3s ease;
+}
+
+.lgp-wrapper {
+  display: table-cell;
+  vertical-align: middle;
+}
+
+.lgp-container {
+  width: 50%;
+  margin: 0px auto;
+  background-color: #fff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, .33);
+  transition: all .3s ease;
+  font-family: Helvetica, Arial, sans-serif;
+
+  .lgp-header {
+    padding: 1px 8px;
+    background-color: $active-bg;
+
+    h1 {
+      font-size: 120%;
+      color: #fff;
+    }
+  }
+
+  .lgp-content {
+    padding: 20px 30px;
+
+    div {
+      padding: 4px 0px;
+    }
+
+    .lgp-error-text {
+      margin-left: 8px;
+      color: red
+    }
+
+    textarea {
+      width: 100%;
+      height: 200px;
+      padding: 3px;
+    }
+  }
+}
+
+.modal-header h3 {
+  margin-top: 0;
+  color: #42b983;
+}
+
+.modal-body {
+  margin: 20px 0;
+}
+
+.modal-default-button {
+  float: right;
+}
+
+/*
+  Transition styles
+*/
+.log-paste-popup-enter {
+  opacity: 0;
+}
+
+.log-paste-popup-leave-active {
+  opacity: 0;
+}
+
+.log-paste-popup-enter .modal-container,
+.log-paste-popup-leave-active .modal-container {
+  -webkit-transform: scale(1.1);
+  transform: scale(1.1);
+}
+</style>

--- a/lsp-inspector/src/components/sidebar/LogPicker.vue
+++ b/lsp-inspector/src/components/sidebar/LogPicker.vue
@@ -1,19 +1,33 @@
 <template>
-  <div class="log-picker">
-    <label for="file">
-      <font-awesome-icon class="fa-icon" icon="upload" />Upload your log
-    </label>
-    <input type="file" id="file" @change="handleFiles">
+  <div>
+    <div class="log-picker">
+      <label for="file">
+        <font-awesome-icon class="fa-icon" icon="upload" />Upload your log
+      </label>
+      <input type="file" id="file" @change="handleFiles">
+    </div>
+    <div class="log-paster" @click="logPasterIsVisible = true">
+      <font-awesome-icon class="fa-icon" icon="paste" />Paste your log
+    </div>
+
+    <log-paste-popup v-if="logPasterIsVisible" @close="logPasterIsVisible = false" />
   </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue'
 import FontAwesomeIcon from '@fortawesome/vue-fontawesome'
+import LogPastePopup from '@/components/sidebar/LogPastePopup.vue'
 
 export default Vue.extend({
   components: {
-    FontAwesomeIcon
+    FontAwesomeIcon,
+    LogPastePopup
+  },
+  data() {
+    return {
+      logPasterIsVisible: false
+    }
   },
   methods: {
     handleFiles(e) {
@@ -65,5 +79,22 @@ input {
   overflow: hidden;
   position: absolute;
   z-index: -1;
+}
+
+.log-paster {
+  padding: 8px 10px;
+  margin: 6px 0px;
+  cursor: pointer;
+
+  .fa-icon {
+    width: 12px;
+    margin-right: 8px;
+  }
+
+  @include transition(background-color);
+
+  &:hover {
+    background-color: $hover-bg;
+  }
 }
 </style>


### PR DESCRIPTION
I added a new method to upload a log: just paste it into a text area and thats it!

Don't know if you want this feature but for me saving the log into a file and then using the file picker to upload it was 20sec too much! That's why I spend 3 hours implementing the paste dialog :smile: 

![image](https://user-images.githubusercontent.com/4148534/48081308-ffcf2900-e1ef-11e8-8d05-68ef23fca261.png)

The paste `Paste your log` button opens a modal dialog:

![image](https://user-images.githubusercontent.com/4148534/48081090-83d4e100-e1ef-11e8-849d-a12d5e6960c0.png)

You can then simply paste the log into the textarea. The name of the log (here `rust-test`) is automatically filled in from the logfile itself. Then click `paste` and the log is added to the list. If there is a log already with the same name, a number is added to the name to make them unique.

![image](https://user-images.githubusercontent.com/4148534/48081551-9b609980-e1f0-11e8-9776-a74d92fd778f.png)

You can cancel the modal dialog by pressing `ESC` or by clicking anywhere outside of the dialog frame.