### PR TITLE
Support parsing GUID ids from rawLogParser

### DIFF
--- a/lsp-inspector/src/logParser/rawLogParser.ts
+++ b/lsp-inspector/src/logParser/rawLogParser.ts
@@ -83,10 +83,10 @@ function extractMsg(msg: string) {
 
   const reSendNotification = /Sending notification '(.*)'/
   const reRecvNotification = /Received notification '(.*)'/
-  const reSendRequest = /Sending request '(.*) - \((\d+)\)'/
-  const reRecvRequest = /Received request '(.*) - \((\d+)\)'/
-  const reSendResponse = /Sending response '(.*) - \((\d+)\)'.*took (\d+ms)/
-  const reRecvResponse = /Received response '(.*) - \((\d+)\)' in (\d+ms)/
+  const reSendRequest = /Sending request '(.*) - \(([0-9a-zA-Z-]+)\)'/
+  const reRecvRequest = /Received request '(.*) - \(([0-9a-zA-Z-]+)\)'/
+  const reSendResponse = /Sending response '(.*) - \(([0-9a-zA-Z-]+)\)'.*took (\d+ms)/
+  const reRecvResponse = /Received response '(.*) - \(([0-9a-zA-Z-]+)\)' in (\d+ms)/
 
   let msgType, msgId, msgLatency
   /* tslint:disable */

--- a/lsp-inspector/tests/unit/logParser/fixture/ids-with-guids.json
+++ b/lsp-inspector/tests/unit/logParser/fixture/ids-with-guids.json
@@ -1,0 +1,48 @@
+[
+  {
+    "time": "15:31:35",
+    "msg": "Received request 'window/showStatus - (90261e77-782b-4ac1-bd52-6abfA0f65A15)'.",
+    "msgId": "90261e77-782b-4ac1-bd52-6abfA0f65A15",
+    "msgKind": "recv-request",
+    "msgType": "window/showStatus",
+    "arg": {
+      "value": "Loading project...",
+      "enable": true
+    }
+  },
+  {
+    "time": "15:31:35",
+    "msg": "Sending response 'window/showStatus - (90261e77-782b-4ac1-bd52-6abfA0f65A15)' took 25ms",
+    "msgId": "90261e77-782b-4ac1-bd52-6abfA0f65A15",
+    "msgKind": "send-response",
+    "msgLatency": "25ms",
+    "msgType": "window/showStatus",
+    "arg": {
+      "value": "",
+      "enable": true
+    }
+  },
+  {
+    "time": "15:31:35",
+    "msg": "Sending request 'window/showStatus - (90261e77-782b-4ac1-bd52-6abfA0f65A15)'.",
+    "msgId": "90261e77-782b-4ac1-bd52-6abfA0f65A15",
+    "msgKind": "send-request",
+    "msgType": "window/showStatus",
+    "arg": {
+      "value": "Loading project...",
+      "enable": true
+    }
+  },
+  {
+    "time": "15:31:35",
+    "msg": "Received response 'window/showStatus - (90261e77-782b-4ac1-bd52-6abfA0f65A15)' in 25ms",
+    "msgId": "90261e77-782b-4ac1-bd52-6abfA0f65A15",
+    "msgKind": "recv-response",
+    "msgLatency": "25ms",
+    "msgType": "window/showStatus",
+    "arg": {
+      "value": "",
+      "enable": true
+    }
+  }
+]

--- a/lsp-inspector/tests/unit/logParser/fixture/ids-with-guids.log
+++ b/lsp-inspector/tests/unit/logParser/fixture/ids-with-guids.log
@@ -1,0 +1,28 @@
+[Trace - 15:31:35] Received request 'window/showStatus - (90261e77-782b-4ac1-bd52-6abfA0f65A15)'.
+Params: {
+    "value": "Loading project...",
+    "enable": true
+}
+
+
+[Trace - 15:31:35] Sending response 'window/showStatus - (90261e77-782b-4ac1-bd52-6abfA0f65A15)' took 25ms
+Params: {
+    "value": "",
+    "enable": true
+}
+
+
+[Trace - 15:31:35] Sending request 'window/showStatus - (90261e77-782b-4ac1-bd52-6abfA0f65A15)'.
+Params: {
+    "value": "Loading project...",
+    "enable": true
+}
+
+
+[Trace - 15:31:35] Received response 'window/showStatus - (90261e77-782b-4ac1-bd52-6abfA0f65A15)' in 25ms
+Params: {
+    "value": "",
+    "enable": true
+}
+
+

--- a/lsp-inspector/tests/unit/logParser/rawLogparser.spec.ts
+++ b/lsp-inspector/tests/unit/logParser/rawLogparser.spec.ts
@@ -2,24 +2,25 @@ import * as fs from 'fs-extra'
 import * as path from 'path'
 import { parseLSPLog } from '@/logParser/rawLogParser'
 
-describe('HelloWorld', () => {
-  it('parses raw log fine', async () => {
-    await testFixture('helloworld')
-    await testFixture('html')
-    await testFixture('10-tslint-dirty-trace')
-    await testFixture('11-crlf')
-  })
+describe('Raw Log Parser Tests', () => {
+  testFixture('helloworld')
+  testFixture('html')
+  testFixture('10-tslint-dirty-trace')
+  testFixture('11-crlf')
+  testFixture('ids-with-guids')
 })
 
-async function testFixture(fixtureName: string) {
-  const log = await fs.readFile(path.resolve(__dirname, `fixture/${fixtureName}.log`), 'utf-8')
-  const expectedJson = await fs.readFile(
-    path.resolve(__dirname, `fixture/${fixtureName}.json`),
-    'utf-8'
-  )
-  const expected = JSON.parse(expectedJson)
+function testFixture(fixtureName: string) {
+  it(`parses ${fixtureName} logs correctly`, async () => {
+    const log = await fs.readFile(path.resolve(__dirname, `fixture/${fixtureName}.log`), 'utf-8')
+    const expectedJson = await fs.readFile(
+      path.resolve(__dirname, `fixture/${fixtureName}.json`),
+      'utf-8'
+    )
+    const expected = JSON.parse(expectedJson)
 
-  const actual = parseLSPLog(log)
+    const actual = parseLSPLog(log)
 
-  expect(actual).toEqual(expected)
+    expect(actual).toEqual(expected)
+  })
 }


### PR DESCRIPTION
Request Ids can be either strings (GUIDs) or numbers. The raw log parser fails if it encounters GUIDs.
This PR modifies the regex to allow that, and adds a test to make sure it is parsed correctly.

For the API in question:
https://github.com/Microsoft/vscode-languageserver-node/blob/master/jsonrpc/src/messages.ts

```ts

/**
 * Request message
 */
export interface RequestMessage extends Message {
	/**
	 * The request id.
	 */
	id: number | string;

        // other members.....
}

/**
 * A response message.
 */
export interface ResponseMessage extends Message {
	/**
	 * The request id.
	 */
	id: number | string | null;

        // other members.....
}
```