### PR TITLE
Fixed 404-Error inside MessageDetail.vue

### DIFF
--- a/lsp-inspector/src/components/message/MessageDetail.vue
+++ b/lsp-inspector/src/components/message/MessageDetail.vue
@@ -20,7 +20,7 @@ export default Vue.extend({
   computed: {
     msgLink() {
       const hash = this.item.msgType.split('/').join('_')
-      return `https://microsoft.github.io/language-server-protocol/specification#${
+      return `https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#${
         hash
       }`
     }


### PR DESCRIPTION
The link inside MessageDetail.vue currently leads to an 404-Error because the URL-Structure changed.